### PR TITLE
#158250856: Display current date and number of upcoming events

### DIFF
--- a/app/src/androidTest/java/com/andela/mrm/room_booking/EventScheduleActivityTest.java
+++ b/app/src/androidTest/java/com/andela/mrm/room_booking/EventScheduleActivityTest.java
@@ -45,7 +45,7 @@ public class EventScheduleActivityTest {
     @Test
     public void closeButtonDisplayed() {
         onView(withId(R.id.layout_close_event_schedule))
-                .check(matches(allOf(isDisplayed(), isClickable(), hasChildCount(2))));
+                .check(matches(allOf(isDisplayed(), isClickable(), hasChildCount(1))));
     }
 
     /**
@@ -53,7 +53,7 @@ public class EventScheduleActivityTest {
      */
     @Test
     public void todayTextDisplayed() {
-        onView(withId(R.id.today_text))
+        onView(withId(R.id.text_current_date))
                 .check(matches(isDisplayed()));
     }
 

--- a/app/src/main/java/com/andela/mrm/room_booking/room_availability/views/EventScheduleActivity.java
+++ b/app/src/main/java/com/andela/mrm/room_booking/room_availability/views/EventScheduleActivity.java
@@ -6,6 +6,7 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 
 import com.andela.mrm.R;
 import com.andela.mrm.adapter.EventScheduleAdapter;
@@ -15,7 +16,9 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -30,6 +33,14 @@ public class EventScheduleActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_event_schedule);
+
+        String currentDate = SimpleDateFormat.getDateInstance().format(new Date());
+
+        TextView upcomingEventsView = findViewById(R.id.text_upcoming_events);
+        TextView dataView = findViewById(R.id.text_current_date);
+
+        // display current system date
+        dataView.setText(currentDate);
 
         String eventsInStringFromIntent = getIntent()
                 .getStringExtra(RoomAvailabilityActivity.EVENTS_IN_STRING);
@@ -47,6 +58,8 @@ public class EventScheduleActivity extends Activity {
         if (eventsInStringFromIntent != null) {
             Type listType = new TypeToken<List<CalendarEvent>>() { }.getType();
             List<CalendarEvent> events = new Gson().fromJson(eventsInStringFromIntent, listType);
+
+            displayUpcomingEventsView(events, upcomingEventsView);
 
             EventScheduleAdapter eventScheduleAdapter =
                     new EventScheduleAdapter(addAvailableTimeSlots(events),
@@ -111,6 +124,19 @@ public class EventScheduleActivity extends Activity {
             return eventListWithAvailableTimeSlots;
         }
 
+    }
+
+    /**
+     * Displays a view detailing the number of upcoming events.
+     *
+     * @param calendarEvents - list of calender events for a day
+     * @param view - text view containing upcoming events count
+     */
+    private void displayUpcomingEventsView(List<CalendarEvent> calendarEvents, TextView view) {
+        int numberOfUpComingEvents = calendarEvents.size();
+        String upcomingEventsDisplayText = "Upcoming Events: " + numberOfUpComingEvents;
+
+        view.setText(upcomingEventsDisplayText);
     }
 
 }

--- a/app/src/main/res/layout-sw600dp/activity_event_schedule.xml
+++ b/app/src/main/res/layout-sw600dp/activity_event_schedule.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -8,40 +7,33 @@
     tools:context="com.andela.mrm.room_booking.room_availability.views.EventScheduleActivity">
 
     <TextView
-        android:id="@+id/today_text"
+        android:id="@+id/text_current_date"
         style="@style/seven_inch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="96dp"
-        android:layout_marginTop="56dp"
-        android:text="Today"
+        android:layout_marginTop="32dp"
         android:textColor="#fff"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Today" />
 
     <LinearLayout
         android:id="@+id/layout_close_event_schedule"
         android:layout_width="82dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="124dp"
+        android:layout_marginEnd="60dp"
         android:layout_marginTop="32dp"
         android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            style="@style/seven_inch"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="10dp"
-            android:text="Close"
-            android:textColor="#fff" />
-
         <ImageView
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_marginTop="2dp"
-            android:src="@drawable/ic_cancel_24dp" />
+            android:src="@drawable/ic_cancel_24dp"
+            android:contentDescription="@string/cancel_icon" />
 
     </LinearLayout>
 
@@ -50,10 +42,24 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
+        android:layout_marginStart="96dp"
         android:layout_marginTop="8dp"
+        android:paddingStart="-14dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/today_text"
-        app:layout_constraintTop_toBottomOf="@+id/today_text"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_upcoming_events"
+        app:layout_constraintVertical_bias="0.043" />
+
+    <TextView
+        android:id="@+id/text_upcoming_events"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/dinpro"
+        android:layout_marginStart="96dp"
+        android:layout_marginTop="4dp"
+        android:textColor="@android:color/white"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_current_date"
+        tools:text="TextView" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout-sw720dp/activity_event_schedule.xml
+++ b/app/src/main/res/layout-sw720dp/activity_event_schedule.xml
@@ -7,16 +7,16 @@
     tools:context="com.andela.mrm.room_booking.room_availability.views.EventScheduleActivity">
 
     <TextView
-        android:id="@+id/today_text"
+        android:id="@+id/text_current_date"
         style="@style/ten_inch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="96dp"
-        android:layout_marginTop="96dp"
-        android:text="Today"
+        android:layout_marginTop="52dp"
         android:textColor="#fff"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Today" />
 
     <LinearLayout
         android:id="@+id/layout_close_event_schedule"
@@ -28,31 +28,38 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            style="@style/ten_inch"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="10dp"
-            android:text="Close"
-            android:textColor="#fff" />
-
         <ImageView
             android:layout_width="30dp"
             android:layout_height="30dp"
             android:layout_marginTop="2dp"
-            android:src="@drawable/ic_cancel_24dp" />
+            android:src="@drawable/ic_cancel_24dp"
+            android:contentDescription="@string/cancel_icon" />
 
     </LinearLayout>
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/layout_event_recycler_view"
         android:layout_width="wrap_content"
-        android:layout_height="400dp"
-        android:layout_marginBottom="236dp"
-        android:layout_marginTop="40dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="56dp"
+        android:layout_marginStart="96dp"
+        android:layout_marginTop="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/today_text"
-        app:layout_constraintTop_toBottomOf="@+id/today_text"
-        app:layout_constraintVertical_bias="0.356" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_upcoming_events"
+        app:layout_constraintVertical_bias="0.188" />
+
+    <TextView
+        android:id="@+id/text_upcoming_events"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/dinpro"
+        android:textSize="18sp"
+        android:layout_marginStart="96dp"
+        android:layout_marginTop="4dp"
+        android:textColor="@android:color/white"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_current_date"
+        tools:text="TextView" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,4 +63,5 @@
     <string name="room_amenities_text">Room Amenities</string>
     <string name="room_name_text">Ol Karia</string>
     <string name="attend_icon">attend_icon</string>
+    <string name="cancel_icon">cancel icon</string>
 </resources>


### PR DESCRIPTION
#### What does this PR do?
- ensures that current date and number of upcoming events are displayed on the event schedule activity layout
#### Description of Task to be completed?
- [x] modify UI and add functionality for displaying current date
- [x] add UI and functionality for displaying number of upcoming events
#### How should this be manually tested?
- clone repo and open in android studio
- sync and launch app
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
- story type - feature
- story title - User can view the count of upcoming events for each day(UI & Functionality)
- story id - #158250856
### Screenshot
![screenshot_1528994314](https://user-images.githubusercontent.com/22524619/41623201-e88f1aec-7409-11e8-9088-de53a44d1768.png)
