### PR TITLE
#158635426 Unit test util classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,10 +543,6 @@ jobs:
           name: Upload coverage to code climate
           command: |
             export JACOCO_SOURCE_PATH=app/src/main/java
-            cp -R app/build/generated/source/apollo/com/andela/mrm/fragment app/src/main/java/com/andela/mrm/
-            cp -R app/build/generated/source/apollo/com/andela/mrm/type app/src/main/java/com/andela/mrm/
-            cp app/build/generated/source/apollo/com/andela/mrm/AllLocationsQuery.java app/src/main/java/com/andela/mrm/
-            cp app/build/generated/source/apollo/com/andela/mrm/RoomQuery.java app/src/main/java/com/andela/mrm/
             cp app/src/prod/java/com/andela/mrm/Injection.java app/src/main/java/com/andela/mrm/Injection.java
             ./cc-test-reporter format-coverage app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml -t jacoco
             ./cc-test-reporter upload-coverage

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ apply from: rootProject.file('app/coverage.gradle')
 apply plugin: 'io.fabric'
 
 jacoco {
-    toolVersion = '0.8.0'
+    toolVersion = "${rootProject.jacocoVersion}"
 }
 
 tasks.withType(Test) {

--- a/app/coverage.gradle
+++ b/app/coverage.gradle
@@ -5,10 +5,6 @@ def coverageSourceDirs = [
         'src/prod/java'
 ]
 
-tasks.withType(Test) {
-    jacoco.includeNoLocationClasses = true
-}
-
 task jacocoTestReport(type: JacocoReport, dependsOn : 'test') {
     description = 'Generate JaCoCo coverage reports'
     group       = 'Reporting'
@@ -35,16 +31,18 @@ task jacocoTestReport(type: JacocoReport, dependsOn : 'test') {
                     '**/*Module_Provide*Factory.*',
                     '**/*_Factory.*',
                     '**/*_MembersInjector.*',
-                    '**/*_LifecycleAdapter.*'
+                    '**/*_LifecycleAdapter.*',
+                    '**/*Query$*',
+                    '**/*Query.*',
+                    '**/com/andela/mrm/fragment',
+                    '**/com/andela/mrm/type'
             ]
     )
 
     sourceDirectories = files(coverageSourceDirs)
     executionData     = fileTree(
             dir     : "$buildDir",
-            include : [ 'jacoco/testMockDebugUnitTest.exec',
-                        'jacoco/testMockReleaseUnitTest.exec',
-                        'outputs/code-coverage/connected/flavors/MOCK/coverage.ec' ]
+            include : ['**/*.exec', '**/*.ec']
     )
 
     doFirst {
@@ -54,5 +52,10 @@ task jacocoTestReport(type: JacocoReport, dependsOn : 'test') {
             }
         }
     }
+}
+
+task unifiedCoverageReport(dependsOn: ['clean', 'createMockDebugCoverageReport', 'jacocoTestReport']) {
+    description = 'Generates coverage report which includes both local unit tests and instrumentation tests'
+    group = 'Reporting'
 }
 

--- a/app/src/main/java/com/andela/mrm/room_booking/room_availability/views/RoomAvailabilityActivity.java
+++ b/app/src/main/java/com/andela/mrm/room_booking/room_availability/views/RoomAvailabilityActivity.java
@@ -24,6 +24,7 @@ import com.andela.mrm.presenter.MakeGoogleCalendarCallPresenter;
 import com.andela.mrm.room_information.RoomInformationActivity;
 import com.andela.mrm.util.GooglePlayService;
 import com.andela.mrm.util.NetworkConnectivityChecker;
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccountCredential;
 import com.google.api.client.googleapis.extensions.android.gms.auth.GooglePlayServicesAvailabilityIOException;
 import com.google.api.client.googleapis.extensions.android.gms.auth.UserRecoverableAuthIOException;
@@ -114,7 +115,7 @@ public class RoomAvailabilityActivity extends AppCompatActivity implements
         setFindRoomLayoutListener();
 
 
-        playService = new GooglePlayService();
+        playService = new GooglePlayService(GoogleApiAvailability.getInstance());
         fragmentManager = getSupportFragmentManager();
         fragmentManager.beginTransaction()
                 .add(R.id.frame_room_availability_details, new MeetingRoomDetailFragment())

--- a/app/src/main/java/com/andela/mrm/room_information/RoomInformationActivity.java
+++ b/app/src/main/java/com/andela/mrm/room_information/RoomInformationActivity.java
@@ -35,6 +35,7 @@ public class RoomInformationActivity extends AppCompatActivity implements
     private int mRoomId;
     ResourcesInfoContract.Actions mPresenter;
     private boolean mIsLoadingData;
+    private Room mRoom;
 
     private TabLayout mTabLayout;
     private ViewPager mViewPager;
@@ -91,6 +92,7 @@ public class RoomInformationActivity extends AppCompatActivity implements
 
     @Override
     public void showRoomInfo(final Room room) {
+        mRoom = room;
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -99,12 +101,21 @@ public class RoomInformationActivity extends AppCompatActivity implements
                 String roomLocation = room.floor().block().name() + ", " + room.floor().name();
                 mLocationText.setText(roomLocation);
 
-                ResourcesInfoFragment resourcesInfoFragment = getResourcesInfoFragment();
-                if (resourcesInfoFragment != null) {
-                    resourcesInfoFragment.showResourcesList(room.resources());
-                }
+                showRoomResources(room);
             }
         });
+    }
+
+    /**
+     * Displays list of room resources in the RoomResourcesFragment.
+     *
+     * @param room room
+     */
+    void showRoomResources(Room room) {
+        ResourcesInfoFragment resourcesInfoFragment = getResourcesInfoFragment();
+        if (resourcesInfoFragment != null && room != null) {
+            resourcesInfoFragment.showResourcesList(room.resources());
+        }
     }
 
     @Override
@@ -161,6 +172,7 @@ public class RoomInformationActivity extends AppCompatActivity implements
     @Override
     public void onViewLoaded() {
         showLoadingIndicator(mIsLoadingData);
+        showRoomResources(mRoom);
     }
 
     /**

--- a/app/src/main/java/com/andela/mrm/room_information/RoomInformationActivity.java
+++ b/app/src/main/java/com/andela/mrm/room_information/RoomInformationActivity.java
@@ -22,6 +22,7 @@ import com.andela.mrm.room_information.resources_info.ResourcesInfoContract;
 import com.andela.mrm.room_information.resources_info.ResourcesInfoFragment;
 import com.andela.mrm.room_information.resources_info.ResourcesInfoFragment.Callbacks;
 import com.andela.mrm.room_information.resources_info.ResourcesInfoPresenter;
+import com.andela.mrm.util.NetworkConnectivityChecker;
 
 /**
  * The Room information activity class.
@@ -122,7 +123,7 @@ public class RoomInformationActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void showErrorMessage(final String message) {
+    public void showErrorMessage(final int message) {
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -136,6 +137,11 @@ public class RoomInformationActivity extends AppCompatActivity implements
                         .show();
             }
         });
+    }
+
+    @Override
+    public boolean isNetworkAvailable() {
+        return NetworkConnectivityChecker.isDeviceOnline(this);
     }
 
     /**

--- a/app/src/main/java/com/andela/mrm/room_information/resources_info/ResourcesInfoContract.java
+++ b/app/src/main/java/com/andela/mrm/room_information/resources_info/ResourcesInfoContract.java
@@ -27,9 +27,16 @@ public interface ResourcesInfoContract {
         /**
          * Show error message.
          *
-         * @param message the message
+         * @param messageResourceId the message
          */
-        void showErrorMessage(String message);
+        void showErrorMessage(int messageResourceId);
+
+        /**
+         * Gets network availability Status from the view.
+         *
+         * @return the boolean
+         */
+        boolean isNetworkAvailable();
     }
 
     /**
@@ -66,10 +73,8 @@ public interface ResourcesInfoContract {
 
             /**
              * On data load failed.
-             *
-             * @param e the e
              */
-            void onDataLoadFailed(Exception e);
+            void onDataLoadFailed();
         }
 
     }

--- a/app/src/main/java/com/andela/mrm/room_information/resources_info/ResourcesInfoFragment.java
+++ b/app/src/main/java/com/andela/mrm/room_information/resources_info/ResourcesInfoFragment.java
@@ -46,6 +46,14 @@ public class ResourcesInfoFragment extends Fragment {
 
 
     @Override
+    public void setUserVisibleHint(boolean isVisibleToUser) {
+        super.setUserVisibleHint(isVisibleToUser);
+        if (isVisibleToUser && mCallbacks != null) {
+            mCallbacks.onViewLoaded();
+        }
+    }
+
+    @Override
     public void onAttach(Context context) {
         super.onAttach(context);
         mCallbacks = (Callbacks) context;

--- a/app/src/main/java/com/andela/mrm/room_information/resources_info/ResourcesInfoPresenter.java
+++ b/app/src/main/java/com/andela/mrm/room_information/resources_info/ResourcesInfoPresenter.java
@@ -1,5 +1,6 @@
 package com.andela.mrm.room_information.resources_info;
 
+import com.andela.mrm.R;
 import com.andela.mrm.fragment.Room;
 import com.andela.mrm.room_information.resources_info.ResourcesInfoContract.Data;
 import com.andela.mrm.room_information.resources_info.ResourcesInfoContract.View;
@@ -34,9 +35,13 @@ public class ResourcesInfoPresenter implements ResourcesInfoContract.Actions {
             }
 
             @Override
-            public void onDataLoadFailed(Exception e) {
+            public void onDataLoadFailed() {
                 mView.showLoadingIndicator(false);
-                mView.showErrorMessage(e.getMessage());
+                if (!mView.isNetworkAvailable()) {
+                    mView.showErrorMessage(R.string.error_internet_connection);
+                    return;
+                }
+                mView.showErrorMessage(R.string.error_data_fetch_message);
             }
         });
     }

--- a/app/src/main/java/com/andela/mrm/room_information/resources_info/ResourcesInfoRepository.java
+++ b/app/src/main/java/com/andela/mrm/room_information/resources_info/ResourcesInfoRepository.java
@@ -3,7 +3,6 @@ package com.andela.mrm.room_information.resources_info;
 import android.content.Context;
 
 import com.andela.mrm.RoomQuery;
-import com.andela.mrm.util.NetworkConnectivityChecker;
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
@@ -34,23 +33,17 @@ public class ResourcesInfoRepository implements ResourcesInfoContract.Data {
         mRoomQuery.clone().enqueue(new ApolloCall.Callback<RoomQuery.Data>() {
             @Override
             public void onResponse(@Nonnull Response<RoomQuery.Data> response) {
-                RoomQuery.GetRoomById result = response.data().getRoomById();
-                if (result != null && !response.hasErrors()) {
-                    callback.onDataLoadSuccess(
-                            response.data().getRoomById().fragments().room());
+                RoomQuery.Data data = response.data();
+                if (response.hasErrors() || data == null) {
+                    callback.onDataLoadFailed();
                     return;
                 }
-                callback.onDataLoadFailed(new
-                        Exception(response.errors().get(0).message()));
+                callback.onDataLoadSuccess(data.getRoomById().fragments().room());
             }
 
             @Override
             public void onFailure(@Nonnull ApolloException e) {
-                if (!NetworkConnectivityChecker.isDeviceOnline(mContext)) {
-                    callback.onDataLoadFailed(new Exception("No network found"));
-                    return;
-                }
-                callback.onDataLoadFailed(new Exception("Could not retrieve data"));
+                callback.onDataLoadFailed();
             }
         });
     }

--- a/app/src/main/java/com/andela/mrm/util/GooglePlayService.java
+++ b/app/src/main/java/com/andela/mrm/util/GooglePlayService.java
@@ -12,7 +12,20 @@ import com.google.android.gms.common.GoogleApiAvailability;
  */
 public class GooglePlayService {
 
+    /**
+     * The Request google play services.
+     */
     static final int REQUEST_GOOGLE_PLAY_SERVICES = 1002;
+    private final GoogleApiAvailability mGoogleApiAvailability;
+
+    /**
+     * Instantiates a new Google play service.
+     *
+     * @param googleApiAvailability the google api availability
+     */
+    public GooglePlayService(GoogleApiAvailability googleApiAvailability) {
+        mGoogleApiAvailability = googleApiAvailability;
+    }
 
     /**
      * Is google play services available boolean.
@@ -21,10 +34,8 @@ public class GooglePlayService {
      * @return the boolean
      */
     public boolean isGooglePlayServicesAvailable(Context context) {
-        GoogleApiAvailability apiAvailability =
-                GoogleApiAvailability.getInstance();
         final int connectionStatusCode =
-                apiAvailability.isGooglePlayServicesAvailable(context);
+                mGoogleApiAvailability.isGooglePlayServicesAvailable(context);
         return connectionStatusCode == ConnectionResult.SUCCESS;
     }
 
@@ -36,8 +47,7 @@ public class GooglePlayService {
      */
     public void showGooglePlayServicesAvailabilityErrorDialog(
             final int connectionStatusCode, Activity activity) {
-        GoogleApiAvailability apiAvailability = GoogleApiAvailability.getInstance();
-        Dialog dialog = apiAvailability.getErrorDialog(
+        Dialog dialog = mGoogleApiAvailability.getErrorDialog(
                 activity,
                 connectionStatusCode,
                 REQUEST_GOOGLE_PLAY_SERVICES);
@@ -51,11 +61,9 @@ public class GooglePlayService {
      * @param activity the activity
      */
     public void acquireGooglePlayServices(Context context, Activity activity) {
-        GoogleApiAvailability apiAvailability =
-                GoogleApiAvailability.getInstance();
         final int connectionStatusCode =
-                apiAvailability.isGooglePlayServicesAvailable(context);
-        if (apiAvailability.isUserResolvableError(connectionStatusCode)) {
+                mGoogleApiAvailability.isGooglePlayServicesAvailable(context);
+        if (mGoogleApiAvailability.isUserResolvableError(connectionStatusCode)) {
             showGooglePlayServicesAvailabilityErrorDialog(connectionStatusCode, activity);
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,4 +65,6 @@
     <string name="attend_icon">attend_icon</string>
     <string name="cancel_icon">cancel icon</string>
     <string name="snackbar_retry_text">RETRY</string>
+    <string name="error_internet_connection">No Internet Connection</string>
+    <string name="error_data_fetch_message">Error retrieving data</string>
 </resources>

--- a/app/src/mock/java/com/andela/mrm/Injection.java
+++ b/app/src/mock/java/com/andela/mrm/Injection.java
@@ -3,13 +3,17 @@ package com.andela.mrm;
 import android.content.Context;
 
 import com.andela.mrm.fragment.Room;
+import com.andela.mrm.fragment.Room.Block;
+import com.andela.mrm.fragment.Room.Floor;
+import com.andela.mrm.fragment.Room.Resource;
 import com.andela.mrm.room_information.resources_info.MockResourcesInfoRepo;
 import com.andela.mrm.room_information.resources_info.ResourcesInfoContract;
 
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
- * An injection module for providing different instances of diff class depending on build flavor.
+ * An injection module for providing instances of different classes depending on build flavor.
  * Mainly useful for providing mock data for tests. (This can be replaced later with Dagger)
  */
 public class Injection {
@@ -21,17 +25,21 @@ public class Injection {
      * @return the resources info contract . data
      */
     public static ResourcesInfoContract.Data provideResourcesInfoData(Context context, int roomId) {
-        Room.Block block = new Room.Block("", "", "");
-        Room.Floor floor = new Room.Floor("", "", "", block);
+        List<Resource> resources = Arrays.asList(
+                new Resource("", "", "Apple TV"),
+                new Resource("", "", "Notebook")
+        );
+        Block block = new Block("", "", "EPIC Tower");
+        Floor floor = new Floor("", "", "4th Floor", block);
         final Room room = new Room(
                 "",
                 String.valueOf(roomId),
                 "cognitio",
                 "",
-                Long.valueOf(roomId),
+                roomId,
                 "",
                 floor,
-                new ArrayList<Room.Resource>());
+                resources);
         return new MockResourcesInfoRepo(room);
     }
 }

--- a/app/src/test/java/com/andela/mrm/room_information/resources_info/ResourcesInfoPresenterTest.java
+++ b/app/src/test/java/com/andela/mrm/room_information/resources_info/ResourcesInfoPresenterTest.java
@@ -1,5 +1,6 @@
 package com.andela.mrm.room_information.resources_info;
 
+import com.andela.mrm.R;
 import com.andela.mrm.fragment.Room;
 
 import org.junit.After;
@@ -11,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Room Resources Info presenter test class.
@@ -45,37 +47,42 @@ public class ResourcesInfoPresenterTest {
     }
 
     /**
-     * Fetch room details calls expected dependency methods.
+     * Fetch room details calls expected view methods with failed request.
      */
     @Test
-    public void fetchRoomDetailsCallsExpectedDependencyMethods() {
+    public void fetchRoomDetails_callsViewShowErrorMessage_withDataLoadFailedDueToServerError() {
+        when(mView.isNetworkAvailable()).thenReturn(true);
+
         mPresenter.fetchRoomDetails();
-        verify(mView).showLoadingIndicator(true);
+
         verify(mData).loadRoom(mCallbackArgumentCaptor.capture());
+        mCallbackArgumentCaptor.getValue().onDataLoadFailed();
+
+        verify(mView).showLoadingIndicator(false);
+        verify(mView).showErrorMessage(R.string.error_data_fetch_message);
     }
 
     /**
      * Fetch room details calls expected view methods with failed request.
      */
     @Test
-    public void fetchRoomDetailsCallsExpectedViewMethodsWithFailedRequest() {
-        // mocks
-        String dataLoadFailedMessage = "something went wrong";
-        Exception dataLoadFailedException = new Exception(dataLoadFailedMessage);
+    public void fetchRoomDetails_callsViewShowErrorMessage_withDataLoadFailedDueToNetworkError() {
+        when(mView.isNetworkAvailable()).thenReturn(false);
 
         mPresenter.fetchRoomDetails();
 
         verify(mData).loadRoom(mCallbackArgumentCaptor.capture());
-        mCallbackArgumentCaptor.getValue().onDataLoadFailed(dataLoadFailedException);
+        mCallbackArgumentCaptor.getValue().onDataLoadFailed();
+
         verify(mView).showLoadingIndicator(false);
-        verify(mView).showErrorMessage(dataLoadFailedMessage);
+        verify(mView).showErrorMessage(R.string.error_internet_connection);
     }
 
     /**
      * Fetch room details calls expected view methods with successful request.
      */
     @Test
-    public void fetchRoomDetailsCallsExpectedViewMethodsWithSuccessfulRequest() {
+    public void fetchRoomDetails_callsExpectedViewMethodsWithSuccessfulRequest() {
         // mock
         Room room = null;
         mPresenter.fetchRoomDetails();

--- a/app/src/test/java/com/andela/mrm/room_information/resources_info/ResourcesInfoRepositoryTest.java
+++ b/app/src/test/java/com/andela/mrm/room_information/resources_info/ResourcesInfoRepositoryTest.java
@@ -1,0 +1,141 @@
+package com.andela.mrm.room_information.resources_info;
+
+import android.content.Context;
+
+import com.andela.mrm.RoomQuery;
+import com.apollographql.apollo.ApolloCall;
+import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.exception.ApolloException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The type Resources info repository test.
+ */
+public class ResourcesInfoRepositoryTest {
+
+    @Mock
+    private RoomQuery.Data mData;
+    @Mock
+    private RoomQuery.GetRoomById mGetRoomById;
+    @Mock
+    private Context mContext;
+    @Mock
+    private ApolloCall<RoomQuery.Data> mQuery;
+    @Mock
+    private ResourcesInfoContract.Data.Callback mCallback;
+    @Mock
+    private Response<RoomQuery.Data> mDataResponse;
+    @Captor
+    private ArgumentCaptor<ApolloCall.Callback<RoomQuery.Data>> mCallbackArgumentCaptor;
+
+    private ResourcesInfoRepository mRepository;
+
+    /**
+     * Sets up.
+     */
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        mRepository = new ResourcesInfoRepository(mContext, mQuery);
+    }
+
+    /**
+     * Load room calls callback data load success with room data when server returns with success.
+     */
+    @Test
+    public void loadRoom_callsCallbackDataLoadSuccessWithRoomData() {
+        RoomQuery.GetRoomById.Fragments fragments =
+                mock(RoomQuery.GetRoomById.Fragments.class);
+        // stubs
+        when(mQuery.clone()).thenReturn(mQuery);
+        when(mDataResponse.data()).thenReturn(mData);
+        when(mDataResponse.hasErrors()).thenReturn(false);
+        when(mData.getRoomById()).thenReturn(mGetRoomById);
+        when(mGetRoomById.fragments()).thenReturn(fragments);
+
+        mRepository.loadRoom(mCallback);
+
+        // calls enqueue with the Apollo Callback Argument
+        verify(mQuery).enqueue(mCallbackArgumentCaptor.capture());
+
+        // when the Callback returns response with no errors and not null data
+        mCallbackArgumentCaptor.getValue().onResponse(mDataResponse);
+
+        verify(mCallback).onDataLoadSuccess(mData.getRoomById().fragments().room());
+
+    }
+
+    /**
+     * Load room calls callback data load failed with null data.
+     */
+    @Test
+    public void loadRoom_callsCallbackDataLoadFailedWithNullData() {
+        // stubs
+        when(mQuery.clone()).thenReturn(mQuery);
+        when(mDataResponse.hasErrors()).thenReturn(false);
+        when(mDataResponse.data()).thenReturn(null);
+
+        mRepository.loadRoom(mCallback);
+
+        // calls enqueue with the Apollo Callback Argument
+        verify(mQuery).enqueue(mCallbackArgumentCaptor.capture());
+
+        // when the Callback returns response with no errors but null data
+        mCallbackArgumentCaptor.getValue().onResponse(mDataResponse);
+
+        // Callback is called with an exception
+        verify(mCallback).onDataLoadFailed();
+    }
+
+    /**
+     * Load room calls callback data load failed with response error.
+     */
+    @Test
+    public void loadRoom_callsCallbackDataLoadFailedWithResponseError() {
+        // stubs
+        when(mQuery.clone()).thenReturn(mQuery);
+        when(mDataResponse.hasErrors()).thenReturn(true);
+        when(mDataResponse.data()).thenReturn(mData);
+
+        mRepository.loadRoom(mCallback);
+
+        // calls enqueue with the Apollo Callback Argument
+        verify(mQuery).enqueue(mCallbackArgumentCaptor.capture());
+
+        // when the Callback returns response with errors
+        mCallbackArgumentCaptor.getValue().onResponse(mDataResponse);
+
+        // Callback is called with DataLoadFailed
+        verify(mCallback).onDataLoadFailed();
+    }
+
+    /**
+     * Load room calls callback data load failed with apollo exception.
+     */
+    @Test
+    public void loadRoom_callsCallbackDataLoadFailedWithApolloException() {
+        // stubs
+        when(mQuery.clone()).thenReturn(mQuery);
+
+        mRepository.loadRoom(mCallback);
+
+        // calls enqueue with the Apollo Callback Argument
+        verify(mQuery).enqueue(mCallbackArgumentCaptor.capture());
+
+        // when the Callback returns response with errors
+        mCallbackArgumentCaptor.getValue().onFailure(mock(ApolloException.class));
+
+        // Callback is called with an exception
+        verify(mCallback).onDataLoadFailed();
+    }
+}

--- a/app/src/test/java/com/andela/mrm/util/GooglePlayServiceTest.java
+++ b/app/src/test/java/com/andela/mrm/util/GooglePlayServiceTest.java
@@ -1,0 +1,82 @@
+package com.andela.mrm.util;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static com.andela.mrm.util.GooglePlayService.REQUEST_GOOGLE_PLAY_SERVICES;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * The Google play service test.
+ */
+public class GooglePlayServiceTest {
+
+    private GooglePlayService mGooglePlayService;
+
+    @Mock
+    private GoogleApiAvailability mGoogleApiAvailability;
+
+
+    /**
+     * Sets up.
+     */
+    @Before
+    public void setUp() {
+        initMocks(this);
+        mGooglePlayService = new GooglePlayService(mGoogleApiAvailability);
+    }
+
+    /**
+     * Is google play services available returns true.
+     */
+    @Test
+    public void isGooglePlayServicesAvailable_returnsTrue() {
+        Context context = any(Context.class);
+        when(mGoogleApiAvailability.isGooglePlayServicesAvailable(context))
+                .thenReturn(ConnectionResult.SUCCESS);
+
+        assertTrue(mGooglePlayService.isGooglePlayServicesAvailable(context));
+    }
+
+
+    /**
+     * Acquire google play services calls show error dialog.
+     */
+    @Test
+    public void acquireGooglePlayServices_callsShowErrorDialog() {
+        Context context = mock(Context.class);
+        Activity activity = mock(Activity.class);
+        Dialog dialog = mock(Dialog.class);
+        int connectionStatusCode = 1;
+        boolean isUserResolvableError = true;
+
+        GooglePlayService googlePlayService = spy(mGooglePlayService);
+
+        // stubs
+        when(mGoogleApiAvailability.isGooglePlayServicesAvailable(context))
+                .thenReturn(connectionStatusCode);
+        when(mGoogleApiAvailability.isUserResolvableError(connectionStatusCode))
+                .thenReturn(isUserResolvableError);
+        when(mGoogleApiAvailability
+                .getErrorDialog(activity, connectionStatusCode, REQUEST_GOOGLE_PLAY_SERVICES))
+                .thenReturn(dialog);
+
+        googlePlayService.acquireGooglePlayServices(context, activity);
+        verify(googlePlayService).
+                showGooglePlayServicesAvailabilityErrorDialog(connectionStatusCode, activity);
+    }
+}

--- a/app/src/test/java/com/andela/mrm/util/NetworkConnectivityCheckerTest.java
+++ b/app/src/test/java/com/andela/mrm/util/NetworkConnectivityCheckerTest.java
@@ -1,0 +1,72 @@
+package com.andela.mrm.util;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * The Network connectivity checker test.
+ */
+public class NetworkConnectivityCheckerTest {
+
+    private Context mContext;
+    private NetworkInfo mNetworkInfo;
+    private ConnectivityManager mConnectivityManager;
+
+    /**
+     * Sets up.
+     */
+    @Before
+    public void setUp() {
+        mContext = Mockito.mock(Context.class);
+        mNetworkInfo = Mockito.mock(NetworkInfo.class);
+        mConnectivityManager = Mockito.mock(ConnectivityManager.class);
+
+    }
+
+    /**
+     * Is device online returns false with unavailable network.
+     */
+    @Test
+    public void isDeviceOnline_ReturnsFalseWithUnavailableNetwork() {
+        when(mContext.getSystemService(Context.CONNECTIVITY_SERVICE))
+                .thenReturn(mConnectivityManager);
+        when(mConnectivityManager.getActiveNetworkInfo()).thenReturn(null);
+
+        assertFalse(NetworkConnectivityChecker.isDeviceOnline(mContext));
+    }
+
+    /**
+     * Is device online returns false with available network but device is not connected.
+     */
+    @Test
+    public void isDeviceOnline_ReturnsFalseWithAvailableNetworkButDeviceIsNotConnected() {
+        when(mContext.getSystemService(Context.CONNECTIVITY_SERVICE))
+                .thenReturn(mConnectivityManager);
+        when(mConnectivityManager.getActiveNetworkInfo()).thenReturn(mNetworkInfo);
+        when(mNetworkInfo.isConnected()).thenReturn(false);
+
+        assertFalse(NetworkConnectivityChecker.isDeviceOnline(mContext));
+    }
+
+    /**
+     * Is device online returns true with available network and connected device.
+     */
+    @Test
+    public void isDeviceOnline_ReturnsTrueWithAvailableNetworkAndConnectedDevice() {
+        when(mContext.getSystemService(Context.CONNECTIVITY_SERVICE))
+                .thenReturn(mConnectivityManager);
+        when(mConnectivityManager.getActiveNetworkInfo()).thenReturn(mNetworkInfo);
+        when(mNetworkInfo.isConnected()).thenReturn(true);
+
+        assertTrue(NetworkConnectivityChecker.isDeviceOnline(mContext));
+    }
+}

--- a/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'org.jacoco:org.jacoco.core:0.8.0'
         classpath 'com.apollographql.apollo:apollo-gradle-plugin:0.5.0'
         classpath 'io.fabric.tools:gradle:1.25.3'
         classpath 'com.google.gms:google-services:3.3.0'
@@ -42,7 +41,7 @@ ext {
     keystoreProperties = new Properties()
     keystoreProperties.load(new FileInputStream(ext.keystorePropertiesFile))
     supportVersion = "27.1.1"
-    jacocoVersion = "0.7.4.201502262128"
+    jacocoVersion = "0.8.1"
     constraintLayout = "1.1.0"
     materialChipsInput = "1.0.8"
     gsonVersion = "2.8.3"


### PR DESCRIPTION
#### What does this PR do?
- Includes unit tests for few util package classes
- Fixes an issue with generating unified coverage report locally with Jacoco. Excludes autogenerated (`ApolloGraphql`) classes from coverage path
- Adds a custom gradle task for generating unified code coverage report locally
- Fixes a subtle bug with displaying room resources with mock data (RoomResourcesInformation feature)

#### How should this be manually tested?
- Clone branch locally in Android Studio and run app on an emulator or a device
- Run tests with the configured gradle tasks

#### Any background context you want to provide?
Generating unified code coverage report locally can be achieved using `./gradlew unifiedCoverageReport`. Due to a [bug](https://issuetracker.google.com/issues/72758547) with `ANDROID_TEST_ORCHESTRATOR`, coverage reports involving instrumentation tests may be incomplete. `ATO` might need to be disabled temporarily before running the task or other coverage-report tasks involving instrumentation tests.

#### What are the relevant pivotal tracker stories?
#158635426