### PR TITLE
#159229754 Optimise gradle build time

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,7 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 android.enableAapt2=true
+
+#Gradle optimisation
+org.gradle.caching=true
+org.gradle.configureondemand=true


### PR DESCRIPTION
# What does this PR do?
Improves gradle build times by optimising the process. It improves the time from an average of ``` 5m 7s 626ms ``` to an average of ``` 1m 6s``` for an initial build and ``` 20s ``` for consecutive builds.

### Screenshots
#### Initial build
![image](https://user-images.githubusercontent.com/33759757/43189674-c7ed2b64-8fff-11e8-9ce7-ba368ecbfd37.png)
#### Subsequent build
![image](https://user-images.githubusercontent.com/33759757/43189844-43a8d852-9000-11e8-935d-ebe6d882cd52.png)

### How should this be manually tested?
1. Clone the repo.
2. Open the project with android studio.
3. Click run and view wait for the gradle build to finish.


### What are the relevant pivotal tracker stories?
159229754
Improve gradle build speeds