### PR TITLE
[Bug 159301276] Fix to DrawRect Method

### DIFF
--- a/app/src/main/java/com/andela/mrm/widget/TimeLineScheduleView.java
+++ b/app/src/main/java/com/andela/mrm/widget/TimeLineScheduleView.java
@@ -259,8 +259,7 @@ public class TimeLineScheduleView extends View {
         final float top = shapeStartYPoint + mRectHeight;
         final float bottom = shapeStartYPoint - mRectHeight;
         final float right = startX + length;
-
-        canvas.drawRect(startX, top, right, bottom, mRectPaint);
+        canvas.drawRect(startX, bottom, right, top, mRectPaint);
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a bug in which the `drawRect()` method in `com/andela/mrm/widget/TimeLineScheduleView.java` which was not rendering the timeline rectangles for API versions less than 22(5.1.1)
#### Description of Task to be completed?
The task completed, required a shuffle of arguments passed to the drawRect method where the shapes are able to render regardless of the API version.
#### How should this be manually tested?
This can be manually tested by;

1. Cloning the repo
2. Checking out to the branch 
3. Running an emulator of api version 22 or less anf viewing the activity 

#### Any background context you want to provide?
A potential Bug with the Canvas API library involving a restructure of the arguments 
#### What are the relevant pivotal tracker stories?
#159301276
#### Screenshots (if appropriate)
![bugfix](https://user-images.githubusercontent.com/30991429/43397154-810800d2-940c-11e8-9fda-05d63a746d04.gif)

#### Questions: